### PR TITLE
Upgrade TailwindCSS 1.x to 2.x

### DIFF
--- a/src/HandlesGeneralScaffolding.php
+++ b/src/HandlesGeneralScaffolding.php
@@ -25,7 +25,7 @@ trait HandlesGeneralScaffolding
 
         file_put_contents(
             base_path('composer.json'),
-            json_encode($composer, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL
+            json_encode($composer, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT) . PHP_EOL
         );
     }
 
@@ -33,12 +33,12 @@ trait HandlesGeneralScaffolding
     {
         if ($dev == 'require-dev') {
             return array_merge([], $composer);
-        } else {
-            return array_merge([
-                'laravel/ui' => '^2.0',
+        }
+
+        return array_merge([
+                'laravel/ui' => '^3.0',
                 'livewire/livewire' => '^2.0',
             ], $composer);
-        }
     }
 
     protected static function updatePackagesScripts(): void
@@ -53,7 +53,7 @@ trait HandlesGeneralScaffolding
 
         file_put_contents(
             base_path('package.json'),
-            json_encode($packages, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL
+            json_encode($packages, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT) . PHP_EOL
         );
     }
 
@@ -61,6 +61,6 @@ trait HandlesGeneralScaffolding
     {
         $filesystem = new Filesystem();
 
-        $filesystem->copyDirectory(__DIR__.'/stubs/default', base_path());
+        $filesystem->copyDirectory(__DIR__ . '/stubs/default', base_path());
     }
 }

--- a/src/TtallPreset.php
+++ b/src/TtallPreset.php
@@ -12,11 +12,13 @@ class TtallPreset extends Preset
     use HandlesCodeHelperScaffolding;
 
     const NPM_PACKAGES_TO_ADD = [
-        '@tailwindcss/ui' => '^0.4',
+        '@tailwindcss/ui' => '^0.7.2',
+        'autoprefixer' => '^9.8.6',
         'alpinejs' => '^2.6',
-        'laravel-mix' => '^5.0.1',
-        'laravel-mix-tailwind' => '^0.1.0',
-        'tailwindcss' => '^1.6',
+        'laravel-mix' => '^5.0.9',
+        'postcss' => '^7.0.35',
+        'postcss-import' => '^12.0.1',
+        'tailwindcss' => 'npm:@tailwindcss/postcss7-compat@^2.0.1',
         'turbolinks' => '^5.2.0',
     ];
 
@@ -70,11 +72,11 @@ class TtallPreset extends Preset
                 static::DEV_NPM_PACKAGES_TO_ADD,
                 Arr::except($packages, static::NPM_PACKAGES_TO_REMOVE)
             );
-        } else {
-            return array_merge(
-                static::NPM_PACKAGES_TO_ADD,
-                Arr::except($packages, static::NPM_PACKAGES_TO_REMOVE)
-            );
         }
+
+        return array_merge(
+            static::NPM_PACKAGES_TO_ADD,
+            Arr::except($packages, static::NPM_PACKAGES_TO_REMOVE)
+        );
     }
 }

--- a/src/TtallPreset.php
+++ b/src/TtallPreset.php
@@ -12,7 +12,6 @@ class TtallPreset extends Preset
     use HandlesCodeHelperScaffolding;
 
     const NPM_PACKAGES_TO_ADD = [
-        '@tailwindcss/ui' => '^0.7.2',
         'autoprefixer' => '^9.8.6',
         'alpinejs' => '^2.6',
         'laravel-mix' => '^5.0.9',

--- a/src/stubs/default/postcss.config.js
+++ b/src/stubs/default/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+    plugins: {
+        tailwindcss: {},
+        autoprefixer: {},
+    },
+}

--- a/src/stubs/default/tailwind.config.js
+++ b/src/stubs/default/tailwind.config.js
@@ -3,13 +3,21 @@ const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {
     theme: {
+        container: {
+            center: true,
+        },
+
         extend: {
             fontFamily: {
                 sans: ['Inter var', ...defaultTheme.fontFamily.sans],
             },
         },
     },
+
+    darkMode: false, // or 'media' or 'class'
+
     variants: {},
+
     purge: {
         content: [
             './app/**/*.php',
@@ -22,12 +30,12 @@ module.exports = {
             './resources/**/*.vue',
             './resources/**/*.twig',
         ],
+
         options: {
             defaultExtractor: (content) => content.match(/[\w-/.:]+(?<!:)/g) || [],
             whitelistPatterns: [/-active$/, /-enter$/, /-leave-to$/, /show$/],
         },
     },
-    plugins: [
-        require('@tailwindcss/ui'),
-    ],
+
+    plugins: [],
 };

--- a/src/stubs/default/webpack.mix.js
+++ b/src/stubs/default/webpack.mix.js
@@ -1,7 +1,5 @@
 const mix = require("laravel-mix");
 
-require("laravel-mix-tailwind");
-
 /*
  |--------------------------------------------------------------------------
  | Mix Asset Management
@@ -16,7 +14,10 @@ require("laravel-mix-tailwind");
 mix.js("resources/js/app.js", "public/js")
     .js('resources/js/turbolinks.js', 'public/js')
     .sass("resources/sass/app.scss", "public/css")
-    .tailwind("./tailwind.config.js")
+    .options({
+        processCssUrls: false,
+        postCss: [require('tailwindcss')],
+    })
     .sourceMaps();
 
 if (mix.inProduction()) {


### PR DESCRIPTION
Tailwindcss has been updated to version 2.0.1 and I made sure to use postcss7 compatibility version just to make sure it doens't blow up. Also, removed `@tailwindcss/ui`, updated the packages versions and relevant config files

Postcss, postcss-imports and autoprefixer have also been added and configured for additional support.